### PR TITLE
Remove -p flag from buildprod script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test-run": "nodemon ./server/index.js",
     "build-dev": "webpack -w --mode development",
-    "build-prod": "webpack -p --mode production",
+    "build-prod": "webpack --mode production",
     "start": "node ./server/index.js"
   },
   "repository": {


### PR DESCRIPTION
Updated build-prod script in package.json. Removed -p flag as it was causing build errors.